### PR TITLE
fix: clean ArticleAdapter extraction artifacts

### DIFF
--- a/src/adapters/article-adapter.ts
+++ b/src/adapters/article-adapter.ts
@@ -5,6 +5,30 @@ import type { SourceType } from '../lib/types.js';
 import type { AdapterParseResult, SourceAdapter } from './source-adapter.js';
 
 const MAX_CHUNK_CHARS = 1200;
+const TAG_PATTERN = /<(?:[^<>"']+|"[^"]*"|'[^']*')*>/g;
+const BLOCK_PATTERN = /<(p|li|blockquote)\b(?:[^>"']+|"[^"]*"|'[^']*')*>([\s\S]*?)<\/\1>/gi;
+
+const decodeEntity = (raw: string): string => {
+  const decimalMatch = raw.match(/^&#(\d+);$/i);
+  if (decimalMatch) {
+    const codePoint = Number.parseInt(decimalMatch[1], 10);
+    if (Number.isFinite(codePoint)) {
+      return String.fromCodePoint(codePoint);
+    }
+    return ' ';
+  }
+
+  const hexMatch = raw.match(/^&#x([0-9a-f]+);$/i);
+  if (hexMatch) {
+    const codePoint = Number.parseInt(hexMatch[1], 16);
+    if (Number.isFinite(codePoint)) {
+      return String.fromCodePoint(codePoint);
+    }
+    return ' ';
+  }
+
+  return raw;
+};
 
 const stripHtml = (html: string): string => {
   return html
@@ -12,13 +36,15 @@ const stripHtml = (html: string): string => {
     .replace(/<style[\s\S]*?<\/style>/gi, ' ')
     .replace(/<noscript[\s\S]*?<\/noscript>/gi, ' ')
     .replace(/<svg[\s\S]*?<\/svg>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(TAG_PATTERN, ' ')
     .replace(/&nbsp;/gi, ' ')
     .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&#39;/gi, "'")
     .replace(/&quot;/gi, '"')
+    .replace(/&#x[0-9a-f]+;|&#\d+;/gi, (entity) => decodeEntity(entity))
     .replace(/\s+/g, ' ')
     .trim();
 };
@@ -48,9 +74,9 @@ const readMetaContent = (html: string, names: string[]): string | undefined => {
 };
 
 const splitIntoParagraphs = (html: string): string[] => {
-  const paragraphMatches = html.match(/<(p|li|blockquote)[^>]*>[\s\S]*?<\/(p|li|blockquote)>/gi) ?? [];
+  const paragraphMatches = [...html.matchAll(BLOCK_PATTERN)];
   const paragraphs = paragraphMatches
-    .map((segment) => stripHtml(segment))
+    .map((match) => stripHtml(match[2] ?? ''))
     .map((segment) => segment.trim())
     .filter((segment) => segment.length > 20);
 

--- a/test/unit/article-adapter.test.ts
+++ b/test/unit/article-adapter.test.ts
@@ -49,3 +49,37 @@ test('ArticleAdapter fails on empty body', async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+test('ArticleAdapter strips class-selector artifacts from HTML attributes', async () => {
+  const adapter = new ArticleAdapter();
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () =>
+    new Response(
+      `
+      <html>
+        <head><title>The dark factory is not the point</title></head>
+        <body>
+          <ul class="hidden sm:mt-0 sm:ml-0 [&#38;>li>a]:block [&#38;>li>a]:px-4 [&#38;>li>a]:py-3">
+            <li><a href="/">Home</a></li>
+          </ul>
+          <article>
+            <p>The dark factory is not the point. Teams still need judgment and design ownership.</p>
+          </article>
+        </body>
+      </html>
+      `,
+      { status: 200, headers: { 'content-type': 'text/html' } }
+    );
+
+  try {
+    const result = await adapter.fetchAndParse({ url: 'https://example.com/dark-factory' });
+    const combined = result.chunks.map((chunk) => chunk.text).join('\n');
+
+    assert.equal(combined.includes('[&>li>a]'), false);
+    assert.equal(combined.includes('&#38;'), false);
+    assert.match(combined, /Teams still need judgment and design ownership\./);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- harden HTML stripping to avoid leaking CSS utility-class fragments from attributes
- decode numeric HTML entities during extraction
- use paragraph block capture that strips inner text only
- add regression test for Tailwind class-selector artifact leakage

## Testing
- /Users/gd/.volta/tools/image/node/22.19.0/bin/node --import tsx --test test/unit/article-adapter.test.ts

Closes #1