### PR TITLE
ci: enable OIDC token permission for @claude comment runs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
- add `id-token: write` to `.github/workflows/claude-review.yml`
- this enables OIDC token env vars for `issue_comment`-triggered Claude runs
- fixes `@claude` comment invocations failing with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`

## Scope
- tiny workflow-only change (1 line)

## Verification
- trigger by commenting `@claude` on an open PR after merge
