### PR TITLE
ci: bump review max-turns from 10 to 15

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,7 +29,7 @@ jobs:
           claude_args: >-
             --allowedTools
             "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --max-turns 10
+            --max-turns 15
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -57,4 +57,4 @@ jobs:
           claude_args: >-
             --allowedTools
             "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --max-turns 10
+            --max-turns 15


### PR DESCRIPTION
## Summary
- Bumps `--max-turns` from 10 to 15 for both `review-pr` and `review-on-demand` jobs
- The test run on PR #17 used 11 turns and hit the cap, exiting with `error_max_turns` before finishing cleanly

## Test plan
- [x] PR #17 confirmed the workflow fix works (inline comments posted successfully)
- This change gives the reviewer enough headroom to complete without hitting the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)